### PR TITLE
Update ldap-groupsync.adoc

### DIFF
--- a/workshop/content/ldap-groupsync.adoc
+++ b/workshop/content/ldap-groupsync.adoc
@@ -560,7 +560,11 @@ select the `ldap` auth mechanism, and use the `fancyuser1` user that you gave
 
 More specifically, the `ose-fancy-dev` group has `cluster-reader`
 permissions, and `fancyuser1` is a member. Remember that the password
-for all of these users is `Op#nSh1ft`.
+for all of these users is:
+
+----
+Op#nSh1ft
+----
 
 [Warning]
 ====


### PR DESCRIPTION
“The installer configured a Route for Prometheus by default. Go ahead and control+click the Prometheus link to open it in your browser. You’ll be greeted with a login screen. Click the Log in with OpenShift button, then select the ldap auth mechanism, and use the fancyuser1 user that you gave cluster-reader privileges to earlier.”  → It doesn’t tell me what the password is for logging into openshift as fancyuser1 - I had to scroll back and find a place where it shows the “oc login” command to figure out the password. You should call out the password here (perhaps making it copy/pasteable) 

-- Moved to text box format for password to separate it from regular block of text as requested