### PR TITLE
Update ldap-groupsync.adoc

### DIFF
--- a/workshop/content/ldap-groupsync.adoc
+++ b/workshop/content/ldap-groupsync.adoc
@@ -544,8 +544,8 @@ prometheus-k8s-openshift-monitoring.{{ ROUTE_SUBDOMAIN }}
 
 [Warning]
 ====
-Before continuing, make sure to go to the OpenShift web console and log out
-by using the dropdown menu at the upper right where it says `kube:admin`.
+Before continuing, make sure to go to the {{ MASTER_URL }}[OpenShift Web Console] (Do not use built-in console)
+and log out by using the dropdown menu at the upper right where it says `kube:admin`.
 Otherwise Prometheus will try to use your `kubeadmin` user to pass through
 authentication. While it will work, it doesn't demonstrate the
 `cluster-reader` role.


### PR DESCRIPTION
Updating to clickable link - also stating not to use the built-in console as requested