### PR TITLE
Update machinesets.adoc

### DIFF
--- a/workshop/content/machinesets.adoc
+++ b/workshop/content/machinesets.adoc
@@ -130,8 +130,8 @@ the one that is shown in the lab guide. You should see a note that the
 oc get machines -n openshift-machine-api
 ----
 
-You probably already have a new entry for a `Machine` with a `STATE` of
-`Pending`. After a few moments, it will have a corresponding EC2 instance ID
+You probably already have new entries for 2 new `Machine` with a `STATE` of
+`Pending`. After a few moments, both will have a corresponding EC2 instance ID
 and will look something like:
 
 ----
@@ -147,7 +147,7 @@ output of:
 oc get nodes
 ----
 
-You should see your fresh and happy new node as the one with a very young age:
+You should see your fresh and happy new nodes. They are the ones with a very young age:
 
 ----
 ip-10-0-166-103.us-east-2.compute.internal   Ready    worker   1m   v1.16.2


### PR DESCRIPTION
- recommended changes “You probably already have a new entry for a Machine with a STATE of Pending” - I actually have *two* new Machines that are created - since the previous commands scaled a machineset with 0 machines to 2. So just a minor wording update to say “You probably have new entries for 2 new Machines with a STATE of Pending. After a few moments, both will have a corresponding EC2 instance id and will look something like:”. And the “You should see your fresh and happy new node” → “You should see your fresh and happy new nodes”